### PR TITLE
:repeat: fix: Update revalidation paths and UI enhancements

### DIFF
--- a/src/actions/categories/createUpdateCategory.ts
+++ b/src/actions/categories/createUpdateCategory.ts
@@ -26,7 +26,8 @@ export const createUpdateCategory = async (formData: FormData) => {
       ? await prisma.category.update({ where: { id }, data: { name, image: image ?? undefined } })
       : await prisma.category.create({ data: { name, image: image ?? undefined } })
 
-    revalidatePath('/admin/categories')
+    revalidatePath('/admin')
+    revalidatePath('/')
 
     return { ok: true, message: id ? 'Categoría actualizada' : 'Categoría creada', category }
   } catch (error) {

--- a/src/actions/products/create-update-product.ts
+++ b/src/actions/products/create-update-product.ts
@@ -57,7 +57,8 @@ export const createUpdateProduct = async (formData: FormData) => {
         }
       })
 
-    revalidatePath('/admin/products')
+    revalidatePath('/admin')
+    revalidatePath('/')
 
     return { ok: true, message: id ? 'Producto actualizado' : 'Producto creado', product }
   } catch (error) {

--- a/src/actions/promotions/createUpdatePromotion.ts
+++ b/src/actions/promotions/createUpdatePromotion.ts
@@ -61,7 +61,8 @@ export const createUpdatePromotion = async (formData: FormData) => {
         }
       })
 
-    revalidatePath('/admin/promotions')
+    revalidatePath('/admin')
+    revalidatePath('/')
 
     return { ok: true, message: id ? 'Promoción actualizada' : 'Promoción creada', promotion }
   } catch (error) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import { Inter, Pacifico, Quicksand } from "next/font/google"
+import { Quicksand } from "next/font/google"
 import { Navbar } from "@/components/navbar"
 import { SidebarCart } from "@/components/sidebar-cart"
 import { Footer } from "@/components/footer"
@@ -12,8 +12,8 @@ import ScrollToTop from "@/components/scroll-to-top/ScrollToTop"
 const inter = Quicksand({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
-  title: "Cocteleria Champotón",
-  description: "Menú digital de cocteles y ensaladas de cocteles de camarón",
+  title: "Coctelería Champotón",
+  description: "Menú digital de cócteles y ensaladas de camarón",
   keywords: [
     "menú digital",
     "menú interactivo",
@@ -21,11 +21,11 @@ export const metadata: Metadata = {
     "digital menu",
     "restaurant menu",
     "food delivery",
-    "cocteles",
+    "cócteles",
     "ensaladas",
-    "cocteles de camarón",
-    "cocteles de mariscos",
-    "cocteles de caldos",
+    "cócteles de camarón",
+    "cócteles de mariscos",
+    "cócteles de caldos",
     "pescado frito",
     "mariscos",
     "caldos",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,12 +28,15 @@ export default async function Home() {
         </section>
 
         {/* Featured Promotions */}
-        <section className="py-6 bg-muted">
-          <div className="container mx-auto px-4">
-            <h2 className="text-2xl font-bold mb-6 text-center">Promociones Destacadas</h2>
-            <PromotionBanner promotions={promotions} />
-          </div>
-        </section>
+        {
+          promotions.length > 0 &&
+          <section className="py-6 bg-muted">
+            <div className="container mx-auto px-4">
+              <h2 className="text-2xl font-bold mb-6 text-center">Promociones Destacadas</h2>
+              <PromotionBanner promotions={promotions} />
+            </div>
+          </section>
+        }
 
         {
           products.length > 0 &&

--- a/src/components/admin/categories-tab.tsx
+++ b/src/components/admin/categories-tab.tsx
@@ -15,11 +15,7 @@ import { createUpdateCategory } from "@/actions/categories/createUpdateCategory"
 import { toast } from "sonner"
 import { deleteCategory } from "@/actions/categories/delete-category-by-id"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from "@/components/ui/dialog"
-
-const categorySchema = z.object({
-  name: z.string().min(3, { message: "El nombre debe tener al menos 3 caracteres" }).max(100),
-  image: z.string().url({ message: "La URL de la imagen no es válida" }).optional().nullable()
-})
+import { categorySchema } from "@/schemas/category.schema"
 
 export default function CategoriesTab() {
   const [categories, setCategories] = useState<Category[]>([])
@@ -119,11 +115,10 @@ export default function CategoriesTab() {
     setIsEditing(false)
     setCurrentCategory(null)
 
-    // Opcional: actualizar la lista con los nuevos datos desde el server
+    // Optional: update the list with the new data from the server
     const updated = await getCategories()
     setCategories(updated)
   }
-
 
   if (isLoading) {
     return <Loading />
@@ -144,7 +139,7 @@ export default function CategoriesTab() {
           </div>
 
           {categories.length === 0 ? (
-            <div className="text-center py-8 text-muted">No hay categorías. ¡Agrega una nueva!</div>
+            <div className="text-center py-8 text-muted-foreground">No hay categorías. ¡Agrega una nueva!</div>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full border-collapse">

--- a/src/schemas/category.schema.ts
+++ b/src/schemas/category.schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const categorySchema = z.object({
+  name: z.string().min(3, { message: "El nombre debe tener al menos 3 caracteres" }).max(100),
+  image: z.string().url({ message: "La URL de la imagen no es válida" }).optional().nullable()
+})
+


### PR DESCRIPTION
Updated revalidation paths in create/update actions to include both admin and root paths to ensure data consistency across the site

- Added conditional rendering for promotions section on homepage
- Improved empty state messaging in admin categories tab
- Updated site metadata for better SEO and branding consistency
- Optimized build process with Prisma generate step

Key fixes:

- Fixed stale data issues by revalidating both admin and public routes after CRUD operations
- Prevented empty promotion section from appearing on homepage
- Corrected spelling in metadata ("cócteles" instead of "cocteles")

Enhanced empty state UI in admin panel with proper styling