### PR TITLE
feat: 💰 Add product options pricing to cart and sidebar

### DIFF
--- a/src/actions/categories/createUpdateCategory.ts
+++ b/src/actions/categories/createUpdateCategory.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 
 const categorySchema = z.object({
   id: z.string().uuid().optional(),

--- a/src/actions/categories/delete-category-by-id.ts
+++ b/src/actions/categories/delete-category-by-id.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 
 export const deleteCategory = async (id: string) => {
   if (!id) return { ok: false, message: 'ID requerido' }

--- a/src/actions/categories/get-categories.ts
+++ b/src/actions/categories/get-categories.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import prisma from "@/lib/prisma";
+import { prisma } from "@/lib/prisma";
 import { Category } from "@/lib/types"
 
 export async function getCategories(): Promise<Category[]> {

--- a/src/actions/categories/get-category-by-id.ts
+++ b/src/actions/categories/get-category-by-id.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 
 export const getCategoryById = async (id: string) => {
   if (!id) return { ok: false, message: 'ID requerido' }

--- a/src/actions/categories/get-category-promotion.ts
+++ b/src/actions/categories/get-category-promotion.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 
 export const getCategoryPromotion = async () => {
   try {

--- a/src/actions/menu/get-phone-number-menu.ts
+++ b/src/actions/menu/get-phone-number-menu.ts
@@ -1,5 +1,5 @@
 'use server'
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 
 export async function getPhoneNumberMenu() {
   try {

--- a/src/actions/products/create-update-product.ts
+++ b/src/actions/products/create-update-product.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 import { productSchema } from '@/schemas/product.schema'
 
 export const createUpdateProduct = async (formData: FormData) => {

--- a/src/actions/products/delete-product-by-id.ts
+++ b/src/actions/products/delete-product-by-id.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 import { getProductById } from './get-product-by-id'
 import { deleteImageFromCloudinary } from './delete-image-from-cloudinary'
 

--- a/src/actions/products/get-product-by-id.ts
+++ b/src/actions/products/get-product-by-id.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 
 export const getProductById = async (id: string) => {
   if (!id) return { ok: false, message: 'ID requerido' }

--- a/src/actions/products/get-products.ts
+++ b/src/actions/products/get-products.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import prisma from "@/lib/prisma"
+import { prisma } from "@/lib/prisma"
 import { Product, ProductOption } from "@/lib/types"
 
 function groupOptionsByType(options: ProductOption[] = []) {

--- a/src/actions/promotions/createUpdatePromotion.ts
+++ b/src/actions/promotions/createUpdatePromotion.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 import { promotionSchema } from '@/schemas/promotion.schema'
 
 export const createUpdatePromotion = async (formData: FormData) => {

--- a/src/actions/promotions/delete-promotion-by-id.ts
+++ b/src/actions/promotions/delete-promotion-by-id.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 import { deleteImageFromCloudinary } from '../products/delete-image-from-cloudinary'
 import { getPromotionById } from '@/actions/promotions/get-promotion-by-id'
 

--- a/src/actions/promotions/get-promotion-by-id.ts
+++ b/src/actions/promotions/get-promotion-by-id.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import prisma from '@/lib/prisma'
+import { prisma } from '@/lib/prisma'
 
 export const getPromotionById = async (id: string) => {
   if (!id) return { ok: false, message: 'ID requerido' }

--- a/src/actions/promotions/get-promotions.ts
+++ b/src/actions/promotions/get-promotions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import prisma from "@/lib/prisma"
+import { prisma } from "@/lib/prisma"
 import { Promotion } from "@/lib/types"
 
 export async function getPromotions(): Promise<Promotion[]> {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,7 +2,7 @@ import bcrypt from 'bcryptjs'
 import NextAuth, { type NextAuthConfig } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
 import { z } from 'zod'
-import prisma from './lib/prisma'
+import { prisma } from '@/lib/prisma'
 
 export const authConfig: NextAuthConfig = {
   pages: {

--- a/src/components/products/product-options-modal.tsx
+++ b/src/components/products/product-options-modal.tsx
@@ -11,6 +11,7 @@ import Image from "next/image"
 import ProductSelector from "./product-selector"
 import { ProductOptionsMultiple } from "./product-options-multiple"
 import { Alert, AlertDescription } from "../ui/alert"
+import { generateCartItemId } from "@/lib/utils"
 
 interface ProductOptionsModalProps {
   product: Product
@@ -30,11 +31,14 @@ export default function ProductOptionsModal({ product, isOpen, onClose }: Produc
   const handleAddToCart = () => {
     if (!selectedOption && selectedOptions.length === 0 && !isVariableOnly) return
 
+    const options = [
+      ...(selectedOption ? [selectedOption] : []),
+      ...(selectedOptions || [])
+    ]
+
     const productWithSelectedOption = {
       ...product,
-      options: selectedOption
-        ? [selectedOption]
-        : selectedOptions,
+      options,
     }
 
     // Add the specified quantity to the cart

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,18 +1,13 @@
+// lib/prisma.ts
 import { PrismaClient } from '@prisma/client'
 
-const prismaClientSingleton = () => {
-  return new PrismaClient()
-}
-
-type PrismaClientSingleton = ReturnType<typeof prismaClientSingleton>
-
 const globalForPrisma = globalThis as unknown as {
-  prisma: PrismaClientSingleton | undefined
+  prisma: PrismaClient | undefined
 }
 
-const prisma = globalForPrisma.prisma ?? prismaClientSingleton()
-
-export default prisma
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient()
 
 if (process.env.NODE_ENV !== 'production') {
   globalForPrisma.prisma = prisma

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { type ClassValue, clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { Product } from "./types"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
@@ -8,6 +9,17 @@ export function cn(...inputs: ClassValue[]) {
 export function formatCurrency(amount: number): string {
   return new Intl.NumberFormat("es-ES", {
     style: "currency",
-    currency: "USD",
+    currency: "MXN",
   }).format(amount)
+}
+
+export function getProductTotal(product: Product): number {
+  const basePrice = product.price
+  const optionsPrice = (product.options || []).reduce((total, option) => {
+    const optionPrice = option.price || 0
+    const optionQuantity = option.quantity || 1
+    return total + optionPrice * optionQuantity
+  }, 0)
+
+  return basePrice + optionsPrice
 }


### PR DESCRIPTION
Integrate product options pricing in cart store and sidebar cart. Enhance cart store to calculate prices including options using getProductTotal and getCartItemTotal. Update sidebar cart to display options and use cartItemId for accurate item tracking.

Key changes:
- Added getProductTotal and getCartItemTotal for option-based pricing
- Updated cart store to use cartItemId for unique product-option combos
- Enhanced sidebar cart to show options and their quantities
- Changed Prisma import to named export in multiple files
- Fixed currency format to MXN in utils